### PR TITLE
Reuse commonly used variables and functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 *.rpm
 .idea
 _try
+
+# Data
+fms-data/
+.env

--- a/build/install.sh
+++ b/build/install.sh
@@ -231,6 +231,7 @@ docker run -d \
   -v fms-data-backups-"${project_id}":"/opt/FileMaker/FileMaker Server/Data/Backups":delegated \
   -v fms-data-databases-"${project_id}":"/opt/FileMaker/FileMaker Server/Data/Databases":delegated \
   -v fms-data-preferences-"${project_id}":"/opt/FileMaker/FileMaker Server/Data/Preferences":delegated \
+  -v fms-data-scripts-"${project_id}":"/opt/FileMaker/FileMaker Server/Data/Scripts":delegated \
   -v fms-dbserver-extensions-"${project_id}":"/opt/FileMaker/FileMaker Server/Database Server/Extensions/":delegated \
   -v fms-http-dotconf-"${project_id}":"/opt/FileMaker/FileMaker Server/HTTPServer/.conf":delegated \
   -v fms-http-conf-"${project_id}":"/opt/FileMaker/FileMaker Server/HTTPServer/conf":delegated \

--- a/build/install.sh
+++ b/build/install.sh
@@ -27,21 +27,6 @@ cd "$pwd" || exit 1
 parent_dir=$(dirname "${pwd}")
 inside_base_path="/opt/FileMaker/FileMaker Server/"
 
-# volume-paths array
-paths=(
-  "fms-admin-conf" "/Admin/conf/"
-  "fms-data-backups" "/Data/Backups/"
-  "fms-data-databases" "/Data/Databases/"
-  "fms-data-preferences" "/Data/Preferences/"
-  "fms-dbserver-extensions" "/Database Server/Extensions/"
-  "fms-conf" "/conf/"
-  "fms-http-dotconf" "/HTTPServer/.conf/"
-  "fms-http-conf" "/HTTPServer/conf/"
-  "fms-http-logs" "/HTTPServer/logs/"
-  "fms-logs" "/Logs/"
-  "fms-webpub-conf" "/Web Publishing/conf/"
-)
-
 # parse config
 function get_setting() {
   grep -Ev '^\s*$|^\s*\#' "$2" | grep -E "\s*$1\s*=" | sed 's/.*=//; s/^ //g'
@@ -123,20 +108,8 @@ esac
 # write to .env
 echo "ID=${project_id}" >../.env
 
-# volume-paths array
-paths=(
-  "fms-admin-conf-${project_id}" "/Admin/conf/"
-  "fms-data-backups-${project_id}" "/Data/Backups/"
-  "fms-data-databases-${project_id}" "/Data/Databases/"
-  "fms-data-preferences-${project_id}" "/Data/Preferences/"
-  "fms-dbserver-extensions-${project_id}" "/Database Server/Extensions/"
-  "fms-conf-${project_id}" "/conf/"
-  "fms-http-dotconf-${project_id}" "/HTTPServer/.conf/"
-  "fms-http-conf-${project_id}" "/HTTPServer/conf/"
-  "fms-http-logs-${project_id}" "/HTTPServer/logs/"
-  "fms-logs-${project_id}" "/Logs/"
-  "fms-webpub-conf-${project_id}" "/Web Publishing/conf/"
-)
+# Load paths
+source ../common/paths.sh
 
 #if [[ ! $c_cert ]] || [[ ! $c_bundle ]] || [[ ! $c_key ]]; then
 #  image_name=centos-fms-19_2

--- a/common/paths.sh
+++ b/common/paths.sh
@@ -1,0 +1,16 @@
+_pwd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source $_pwd/settings.sh
+
+paths=(
+  "fms-admin-conf-${project_id}" "/Admin/conf/"
+  "fms-data-backups-${project_id}" "/Data/Backups/"
+  "fms-data-databases-${project_id}" "/Data/Databases/"
+  "fms-data-preferences-${project_id}" "/Data/Preferences/"
+  "fms-dbserver-extensions-${project_id}" "/Database Server/Extensions/"
+  "fms-conf-${project_id}" "/conf/"
+  "fms-http-dotconf-${project_id}" "/HTTPServer/.conf/"
+  "fms-http-conf-${project_id}" "/HTTPServer/conf/"
+  "fms-http-logs-${project_id}" "/HTTPServer/logs/"
+  "fms-logs-${project_id}" "/Logs/"
+  "fms-webpub-conf-${project_id}" "/Web Publishing/conf/"
+)

--- a/common/paths.sh
+++ b/common/paths.sh
@@ -6,6 +6,7 @@ paths=(
   "fms-data-backups-${project_id}" "/Data/Backups/"
   "fms-data-databases-${project_id}" "/Data/Databases/"
   "fms-data-preferences-${project_id}" "/Data/Preferences/"
+  "fms-data-scripts-${project_id}" "/Data/Scripts"
   "fms-dbserver-extensions-${project_id}" "/Database Server/Extensions/"
   "fms-conf-${project_id}" "/conf/"
   "fms-http-dotconf-${project_id}" "/HTTPServer/.conf/"

--- a/common/settings.sh
+++ b/common/settings.sh
@@ -1,0 +1,16 @@
+# Parse config
+function get_setting() {
+  grep -Ev '^\s*$|^\s*\#' "$2" | grep -E "\s*$1\s*=" | sed 's/.*=//; s/^ //g'
+}
+
+function check_setting() {
+  if [[ $(wc -l <<<"$1") -gt 1 ]]; then
+    echo "multiple values found, 1 expected" >&2
+    exit 1
+  fi
+}
+
+# Get settings from config
+_pwd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+project_id=$(get_setting "ID" $_pwd/../.env)
+check_setting "$project_id"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,77 +54,12 @@ services:
     tty: true
     # command: /usr/sbin/init
 
-  d-fms2.fmgarage.com:
-    # reverse proxy test
-    image: centos-fms-19_2:2021-03-25
-    container_name: fms2
-    hostname: d-fms2.fmgarage.com
-    depends_on:
-      - reverse
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-      # - ./data/:/opt/FileMaker/FileMaker Server/Data/Databases/
-      # - ./build/:/root/build/
-    tmpfs:
-      - /tmp
-      - /run
-      - /run/lock
-    security_opt:
-      - seccomp:unconfined
-    user: root
-    environment:
-      - container=docker
-    cap_add:
-      - SYS_ADMIN
-    # ports:
-    #   - 80:80
-    #   - 443:443
-    #   - 2399:2399
-    #   - 5003:5003
-    #   - 16000-16002:16000-16002
-    networks:
-      fms:
-        ipv4_address: 172.20.0.12
-    logging:
-      driver: "json-file"
-      options:
-        mode: "non-blocking"
-        max-size: "10m"
-        max-file: "5"
-    # init: true
-    # privileged: true
-    stop_signal: SIGRTMIN+3
-    restart: "no"
-    stdin_open: true
-    tty: true
-    # command: bash
-
-  reverse:
-    container_name: reverse
-    hostname: reverse
-    image: nginx
-    ports:
-      - 80:80
-      - 443:443
-      - 5003:5003
-      - 16000:16000
-    networks:
-      fms:
-        ipv4_address: 172.20.0.50
-    volumes:
-      - ./nginx_config:/etc/nginx
-      - ./nginx_cert/:/etc/ssl/fmg/
-    # command: bash
-
 networks:
   fms:
     external:
       name: fms-net
 
 volumes:
-#  tmpvolume:
-#    external: true
-#  fms-admin-conf:
   fms-admin-conf:
     name: fms-admin-conf-${ID}
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - fms-data-backups:/opt/FileMaker/FileMaker Server/Data/Backups/:delegated
       - fms-data-databases:/opt/FileMaker/FileMaker Server/Data/Databases/:delegated
       - fms-data-preferences:/opt/FileMaker/FileMaker Server/Data/Preferences/:delegated
+      - fms-data-scripts:/opt/FileMaker/FileMaker Server/Data/Scripts/:delegated
       - fms-dbserver-extensions:/opt/FileMaker/FileMaker Server/Database Server/Extensions/:delegated
       - fms-http-dotconf:/opt/FileMaker/FileMaker Server/HTTPServer/.conf:delegated
       - fms-http-conf:/opt/FileMaker/FileMaker Server/HTTPServer/conf:delegated
@@ -74,6 +75,9 @@ volumes:
     external: true
   fms-data-preferences:
     name: fms-data-preferences-${ID}
+    external: true
+  fms-data-scripts:
+    name: fms-data-scripts-${ID}
     external: true
   fms-conf:
     name: fms-conf-${ID}

--- a/tools/remove_project.sh
+++ b/tools/remove_project.sh
@@ -5,21 +5,8 @@
 pwd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 cd "$pwd" || exit 1
 
-# parse config
-function get_setting() {
-  grep -Ev '^\s*$|^\s*\#' "$2" | grep -E "\s*$1\s*=" | sed 's/.*=//; s/^ //g'
-}
-
-function check_setting() {
-  if [[ $(wc -l <<<"$1") -gt 1 ]]; then
-    echo "multiple values found, 1 expected" >&2
-    exit 1
-  fi
-}
-
-# get settings from config
-project_id=$(get_setting "ID" ../.env) || { printf "error while reading .env file\n"; exit 1; }
-check_setting "$project_id"
+# get settings
+source ../common/settings.sh
 [ -z "$project_id" ] && { printf "error: project ID empty!\n"; exit 1; }
 container_name=fms-${project_id}
 

--- a/tools/setup_project.sh
+++ b/tools/setup_project.sh
@@ -18,36 +18,9 @@ md5-sum() {
   fi
 }
 
-# parse config
-function get_setting() {
-  grep -Ev '^\s*$|^\s*\#' "$2" | grep -E "\s*$1\s*=" | sed 's/.*=//; s/^ //g'
-}
-
-function check_setting() {
-  if [[ $(wc -l <<<"$1") -gt 1 ]]; then
-    echo "multiple values found, 1 expected" >&2
-    exit 1
-  fi
-}
-
-# get settings from config
-project_id=$(get_setting "ID" ../.env)
-check_setting "$project_id"
-
-# volume-paths array
-paths=(
-  "fms-admin-conf-${project_id}" "/Admin/conf/"
-  "fms-data-backups-${project_id}" "/Data/Backups/"
-  "fms-data-databases-${project_id}" "/Data/Databases/"
-  "fms-data-preferences-${project_id}" "/Data/Preferences/"
-  "fms-dbserver-extensions-${project_id}" "/Database Server/Extensions/"
-  "fms-conf-${project_id}" "/conf/"
-  "fms-http-dotconf-${project_id}" "/HTTPServer/.conf/"
-  "fms-http-conf-${project_id}" "/HTTPServer/conf/"
-  "fms-http-logs-${project_id}" "/HTTPServer/logs/"
-  "fms-logs-${project_id}" "/Logs/"
-  "fms-webpub-conf-${project_id}" "/Web Publishing/conf/"
-)
+# Load Variables
+source ../common/settings.sh
+source ../common/paths.sh
 
 # check directories
 printf "\n\e[36mChecking directories on host...\e[39m\n"
@@ -94,20 +67,9 @@ esac
 # write to .env
 echo "ID=${project_id}" >../.env
 
-# reset paths
-paths=(
-  "fms-admin-conf-${project_id}" "/Admin/conf/"
-  "fms-data-backups-${project_id}" "/Data/Backups/"
-  "fms-data-databases-${project_id}" "/Data/Databases/"
-  "fms-data-preferences-${project_id}" "/Data/Preferences/"
-  "fms-dbserver-extensions-${project_id}" "/Database Server/Extensions/"
-  "fms-conf-${project_id}" "/conf/"
-  "fms-http-dotconf-${project_id}" "/HTTPServer/.conf/"
-  "fms-http-conf-${project_id}" "/HTTPServer/conf/"
-  "fms-http-logs-${project_id}" "/HTTPServer/logs/"
-  "fms-logs-${project_id}" "/Logs/"
-  "fms-webpub-conf-${project_id}" "/Web Publishing/conf/"
-)
+# Reset variables
+source ../common/settings.sh
+source ../common/paths.sh
 
 # create bind volumes
 printf "\n\e[36mcreating volumes...\e[39m\n"

--- a/tools/start_server.sh
+++ b/tools/start_server.sh
@@ -43,7 +43,7 @@ function setup_volumes() {
 # check volumes
 function check_volumes() {
   printf "WSL linux, checking bind volumes...\n"
-  if [ "$(find /mnt/wsl/docker-desktop-bind-mounts/${WSL_DISTRO_NAME}/ -maxdepth 1 -type d | wc -l)" -lt 12 ]; then
+  if [ "$(find /mnt/wsl/docker-desktop-bind-mounts/${WSL_DISTRO_NAME}/ -maxdepth 1 -type d | wc -l)" -lt 13 ]; then
     setup_volumes
   fi
 }

--- a/tools/start_server.sh
+++ b/tools/start_server.sh
@@ -55,7 +55,7 @@ else
 fi
 
 volume_count=$(docker volume ls -q --filter="name=${project_id}$")
-volume_count_goal=$(expr ${#paths[@]} / 2)
+volume_count_goal=$((${#paths[@]} / 2))
 if [[ $(wc -l <<<"$volume_count") -ne $volume_count_goal ]]; then
   echo "setting up volumes"
   setup_volumes

--- a/tools/stop_server.sh
+++ b/tools/stop_server.sh
@@ -6,22 +6,8 @@ pwd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 cd "$pwd" || exit 1
 parent_dir=$(dirname "${pwd}")
 
-# parse config
-function get_setting() {
-  grep -Ev '^\s*$|^\s*\#' "$2" | grep -E "\s*$1\s*=" | sed 's/.*=//; s/^ //g'
-}
-
-function check_setting() {
-  if [[ $(wc -l <<<"$1") -gt 1 ]]; then
-    echo "multiple values found, 1 expected" >&2
-    exit 1
-  fi
-}
-
-# get settings from config
-project_id=$(get_setting "ID" ../.env)
-check_setting "$project_id"
-[ -z "$project_id" ] && { printf "error: project ID empty!\nrun setup_project to set an ID.\n"; exit 1; }
+# Load Variables
+source ../common/settings.sh
 
 ## stop that nasty service
 #printf "\nNow stopping httpd service ....\n"


### PR DESCRIPTION
The `$paths` and `$project_id` variable are reused in multiple files. To make adding a new volume easier and reduce complexity, I moved them into a new `common` folder. In the future I would suggest to move other commonly done things (like creating docker volumes, etc.) into the same folder.